### PR TITLE
IMDSv2 lookup, range-aware firewall checks, per-host rule reuse, and SP context cleanup

### DIFF
--- a/Scripts/configure-azure_firewall.ps1
+++ b/Scripts/configure-azure_firewall.ps1
@@ -1,56 +1,145 @@
+[CmdletBinding()]
 param (
-    [Parameter(Mandatory=$true)]
-    [string] $azure_sql_server
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $AzureSqlServer,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string] $ResourceGroupName = "dbregressiontest",
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string] $SubscriptionId = "739c4e86-bd75-4910-8d6e-d7eb23ab94f3",
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string] $TenantId = "17e16064-c148-4c9b-9892-bb00e9589aa5",
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string] $SecretId = "password/ServicePrincipalAzure"
 )
+
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
 
-try {
-    Write-Host( "Getting Azure Service Principle and Secret from AWS Secret Manager")
-    $spappid = Get-SECSecretValue -SecretId "password/ServicePrincipalAzure" -Select SecretString | ConvertFrom-Json | Select-Object -ExpandProperty UID
-    $sppassword = Get-SECSecretValue -SecretId "password/ServicePrincipalAzure" -Select SecretString | ConvertFrom-Json | Select-Object -ExpandProperty PWD | ConvertTo-SecureString -AsPlainText -Force
+function Get-PublicIPAddress {
+    # Prefer EC2 instance metadata (IMDSv2) - we are on AWS, this is the authoritative source
+    try {
+        $token = Invoke-RestMethod `
+            -Uri "http://169.254.169.254/latest/api/token" `
+            -Method PUT `
+            -Headers @{ "X-aws-ec2-metadata-token-ttl-seconds" = "60" } `
+            -TimeoutSec 5
 
-    $subscription = "739c4e86-bd75-4910-8d6e-d7eb23ab94f3"
-    $tenant = "17e16064-c148-4c9b-9892-bb00e9589aa5"
-    $pscredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $spappid, $sppassword
-    Connect-AzAccount -ServicePrincipal -Credential $pscredential -SubscriptionId $subscription -Tenant $tenant
-    Set-AzContext -Tenant $tenant -SubscriptionId $subscription
+        $ip = Invoke-RestMethod `
+            -Uri "http://169.254.169.254/latest/meta-data/public-ipv4" `
+            -Headers @{ "X-aws-ec2-metadata-token" = $token } `
+            -TimeoutSec 5
 
-    Write-Host "Retrieving the Public IP Address of this VM..."
-    $Ip = (Invoke-WebRequest "https://myexternalip.com/raw" -UseBasicParsing)
-    Write-Host( $ip.Content)
-
-    # strip CR or LF from string and return Ip Address
-    $ip_address_to_whitelist_on_Azure_SQLServer = $Ip.content -replace "`t|`n|`r",""
-
-    Write-Host( "Retrieving all the IP addresses in the Azure SQL Server Firewall Rule, $azure_sql_server" )
-    $StartIPAddressList = (Get-AzSqlServerFirewallRule -ResourceGroupName dbregressiontest -ServerName $azure_sql_server).StartIpAddress
-    $StartIPAddressList
-    
-    # At times the EC2 IP address retrieved have been null...
-    if ($ip_address_to_whitelist_on_Azure_SQLServer) {
-
-        Write-Host("Ensuring that $ip_address_to_whitelist_on_Azure_SQLServer is in Azure SQL Server firewall")
-        # This will execute if the EC2 instance's IP address is NOT in the list of IP addresses of the SQL Server Firewall Rule
-        if (!($ip_address_to_whitelist_on_Azure_SQLServer -in $StartIPAddressList)) {
-
-            $current_time = Get-Date -UFormat "%m-%d-%YT%R" # Example: "11-01-2022T14:21" -This will be appended in the Firewall Rule name 
-
-            Write-Host "Updating Azure SQL Server Firewall rule..."
-            
-            New-AzSqlServerFirewallRule -ResourceGroupName dbregressiontest `
-                                            -ServerName $azure_sql_server `
-                                            -StartIpAddress $ip_address_to_whitelist_on_Azure_SQLServer `
-                                            -EndIpAddress $ip_address_to_whitelist_on_Azure_SQLServer `
-                                            -FirewallRuleName "$env:computername-$current_time"
-        } else {
-            Write-Host "IP address already in Firewall." 
-        }
-    } else { 
-        Write-Host "IP Not found. Please check the parameters, and/or if the machine actually exists." 
-        throw
+        return $ip.Trim()
+    } catch {
+        Write-Host "EC2 metadata unavailable, falling back to external IP service..."
     }
 
-} catch {
-    $_ | Out-Default | Write-Host
-    throw
+    # Fallback - external service. The metadata path above has been flaky in the past.
+    try {
+        $response = Invoke-WebRequest -Uri "https://myexternalip.com/raw" -UseBasicParsing -TimeoutSec 10
+        return $response.Content.Trim()
+    } catch {
+        throw "Could not determine public IP via EC2 metadata or external service: $_"
+    }
+}
+
+function ConvertTo-IPv4UInt32 {
+    param([string] $IpString)
+    $bytes = [System.Net.IPAddress]::Parse($IpString).GetAddressBytes()
+    [Array]::Reverse($bytes)
+    return [BitConverter]::ToUInt32($bytes, 0)
+}
+
+function Find-CoveringFirewallRule {
+    param(
+        [string] $IpAddress,
+        [object[]] $Rules
+    )
+
+    if (-not $Rules) { return $null }
+
+    $target = ConvertTo-IPv4UInt32 $IpAddress
+    foreach ($rule in $Rules) {
+        $start = ConvertTo-IPv4UInt32 $rule.StartIpAddress
+        $end = ConvertTo-IPv4UInt32 $rule.EndIpAddress
+        if ($target -ge $start -and $target -le $end) {
+            return $rule
+        }
+    }
+    return $null
+}
+
+$connected = $false
+
+try {
+    Write-Host "Retrieving Azure service principal from AWS Secrets Manager..."
+    $secret = Get-SECSecretValue -SecretId $SecretId -Select SecretString | ConvertFrom-Json
+    $appId = $secret.UID
+    $appSecret = ConvertTo-SecureString -String $secret.PWD -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $appId, $appSecret
+
+    Write-Host "Connecting to Azure (tenant $TenantId, subscription $SubscriptionId)..."
+    Connect-AzAccount `
+        -ServicePrincipal `
+        -Credential $credential `
+        -SubscriptionId $SubscriptionId `
+        -Tenant $TenantId | Out-Null
+    $connected = $true
+
+    Write-Host "Retrieving the public IP address of this VM..."
+    $publicIp = Get-PublicIPAddress
+    # At times the EC2 IP address retrieved has been null - guard explicitly
+    if (-not $publicIp) {
+        throw "Could not determine public IP for $env:COMPUTERNAME"
+    }
+    Write-Host "Public IP: $publicIp"
+
+    Write-Host "Fetching existing firewall rules for $AzureSqlServer..."
+    $existingRules = @(Get-AzSqlServerFirewallRule `
+            -ResourceGroupName $ResourceGroupName `
+            -ServerName $AzureSqlServer)
+
+    # check ranges, not just single-IP rules - a CIDR-style range that already covers us means we are done
+    $coveringRule = Find-CoveringFirewallRule -IpAddress $publicIp -Rules $existingRules
+    if ($coveringRule) {
+        Write-Host "IP $publicIp already covered by firewall rule '$($coveringRule.FirewallRuleName)'."
+        return
+    }
+
+    # reuse one rule per host to avoid accumulating stale entries (Azure SQL caps at 128 server-level rules)
+    $ruleName = "auto-$env:COMPUTERNAME"
+    $existing = $existingRules | Where-Object { $_.FirewallRuleName -eq $ruleName }
+
+    if ($existing) {
+        Write-Host "Updating existing rule '$ruleName' -> $publicIp..."
+        Set-AzSqlServerFirewallRule `
+            -ResourceGroupName $ResourceGroupName `
+            -ServerName $AzureSqlServer `
+            -FirewallRuleName $ruleName `
+            -StartIpAddress $publicIp `
+            -EndIpAddress $publicIp | Out-Null
+    } else {
+        Write-Host "Creating new firewall rule '$ruleName' for $publicIp..."
+        New-AzSqlServerFirewallRule `
+            -ResourceGroupName $ResourceGroupName `
+            -ServerName $AzureSqlServer `
+            -FirewallRuleName $ruleName `
+            -StartIpAddress $publicIp `
+            -EndIpAddress $publicIp | Out-Null
+    }
+
+    Write-Host "Done."
+} finally {
+    if ($connected) {
+        Disconnect-AzAccount | Out-Null
+    }
 }


### PR DESCRIPTION
Hi all,

This PR I made does the following: 

Switch public IP lookup to **EC2 IMDSv2** with `myexternalip.com` as a fallback, removing the hard third-party dependency in the happy path and using the authoritative AWS source. Both requests now have explicit timeouts so a hung endpoint cannot stall the run, and the lookup throws a real error message on failure instead of a bare `throw`.

Reuse a single firewall rule per host (`auto-$COMPUTERNAME`) instead of creating a new timestamped rule every run. The previous behavior accumulated rules indefinitely and would eventually hit Azure SQL's **128 server-level rule cap**. Membership is now checked against full rule ranges (`StartIpAddress`..`EndIpAddress`) rather than just `StartIpAddress`, so existing CIDR-style rules that already cover the host are honored and no duplicate is created.

Consolidate AWS Secrets Manager into a single `Get-SECSecretValue` call and read `UID`/`PWD` off one object (same fix as #92). Wrap the run in `try`/`finally` with `Disconnect-AzAccount` so the service-principal context does not leak between runs on shared runners. Drop the redundant `Set-AzContext` call since `Connect-AzAccount -SubscriptionId` already sets context.

Parameterize `ResourceGroupName`, `SubscriptionId`, `TenantId`, and `SecretId` so the script is not pinned to one tenant or RG. Add `[CmdletBinding()]`, `Set-StrictMode -Version Latest`, and `[ValidateNotNullOrEmpty()]` on string params. Remove the silent `$StartIPAddressList` debug print and the no-op `$_ | Out-Default | Write-Host` in the catch.

Cheers,
Michael Mendy.